### PR TITLE
Require lodash.clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "fbjs": "0.4.0",
     "has-own-prop": "1.0.0",
+    "lodash.clone": "^3.0.3",
     "react": "^0.14.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`src/menuBar.js` requires `lodash.clone` but it's not a dependency. This adds it.
